### PR TITLE
Cleanup containers when a build fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,27 @@ lxd and builds snap packages of the provided source trees.
 
 Once the snap is installed, it needs its interfaces to be connected:
 ```bash
+snap install lxd
+sudo lxd init # hit enter for all questions
+
 sudo snap install fabrica
 
 sudo snap connect fabrica:lxd lxd:lxd
 sudo snap connect fabrica:mount-observe :mount-observe
 sudo snap connect fabrica:system-observe :system-observe
 ```
+
+## Options
+Fabrica has a configuration option that may be useful for a development environment:
+- `debug=true`: (default false) if a build fails, the LXD container is retained for debugging
+
+Options can be set using a `snap set` command e.g.
+```
+sudo snap set fabrica debug=true
+```
+
+If the `debug` option is used, the container will need to be deleted manually to
+recover disk space.
 
 ## Development Environment
 The build needs Go 13.* and npm installed.

--- a/fabrica.go
+++ b/fabrica.go
@@ -21,19 +21,19 @@ func main() {
 
 	// Set up the dependency chain
 	db, _ := sqlite.NewDatabase()
-	buildSrv := repo.NewBuildService(db)
+	systemSrv := system.NewSystemService()
+	lxdSrv := lxd.NewLXD(db, systemSrv)
+	buildSrv := repo.NewBuildService(db, lxdSrv)
 
 	// Set up the service based on the mode
 	if mode == "watch" {
 		watchDaemon(db, buildSrv)
 	} else {
-		webService(settings, buildSrv)
+		webService(settings, buildSrv, lxdSrv, systemSrv)
 	}
 }
 
-func webService(settings *config.Settings, buildSrv *repo.BuildService) {
-	lxdSrv := lxd.NewLXD("", nil)
-	systemSrv := system.NewSystemService()
+func webService(settings *config.Settings, buildSrv *repo.BuildService, lxdSrv lxd.Service, systemSrv system.Srv) {
 	srv := web.NewWebService(settings, buildSrv, lxdSrv, systemSrv)
 	srv.Start()
 }

--- a/service/lxd/lxd.go
+++ b/service/lxd/lxd.go
@@ -2,17 +2,13 @@ package lxd
 
 import (
 	"fmt"
-	"github.com/lxc/lxd/client"
-	"github.com/lxc/lxd/shared/api"
+	lxd "github.com/lxc/lxd/client"
 	"github.com/ogra1/fabrica/datastore"
 	"github.com/ogra1/fabrica/domain"
-	"github.com/ogra1/fabrica/service"
-	"github.com/ogra1/fabrica/service/writecloser"
-	"io"
+	"github.com/ogra1/fabrica/service/system"
 	"log"
 	"os"
 	"path"
-	"strings"
 	"time"
 )
 
@@ -33,109 +29,31 @@ var containerCmd = [][]string{
 
 // Service is the interface for the LXD service
 type Service interface {
-	RunBuild(name, repo, distro string) error
+	RunBuild(buildID, name, repo, distro string) error
 	GetImageAlias(name string) error
 	CheckConnections() []domain.SettingAvailable
 }
 
 // LXD services
 type LXD struct {
-	BuildID   string
 	Datastore datastore.Datastore
+	SystemSrv system.Srv
 }
 
 // NewLXD creates a new LXD client
-func NewLXD(buildID string, ds datastore.Datastore) *LXD {
+func NewLXD(ds datastore.Datastore, sysSrv system.Srv) *LXD {
 	return &LXD{
-		BuildID:   buildID,
 		Datastore: ds,
+		SystemSrv: sysSrv,
 	}
 }
 
-// RunBuild launches an LXD container to start the build
-func (lx *LXD) RunBuild(name, repo, distro string) error {
-	log.Println("Run build:", name, repo, distro)
-	log.Println("Creating and starting container")
-	lx.Datastore.BuildLogCreate(lx.BuildID, "milestone: Creating and starting container")
-
-	// Connect to the lxd service
-	c, err := lx.connect()
-	if err != nil {
-		return err
-	}
-
-	// Generate the container name
-	cname := containerName(name)
-
-	// Create and start the LXD
-	lx.Datastore.BuildLogCreate(lx.BuildID, "milestone: Create container "+cname)
-	if err := lx.createAndStartContainer(c, cname, distro); err != nil {
-		log.Println("Error creating/starting container:", err)
-		lx.Datastore.BuildLogCreate(lx.BuildID, err.Error())
-		return err
-	}
-
-	// Set up the database writer for the logs
-	dbWC := writecloser.NewDBWriteCloser(lx.BuildID, lx.Datastore)
-
-	// Wait for the network to be running
-	lx.Datastore.BuildLogCreate(lx.BuildID, "milestone: Waiting for the network")
-	lx.waitForNetwork(c, cname)
-	lx.Datastore.BuildLogCreate(lx.BuildID, "milestone: Network is ready")
-
-	// Set up the container
-	commands := append(containerCmd, []string{"git", "clone", "--progress", repo})
-
-	lx.Datastore.BuildLogCreate(lx.BuildID, "milestone: Install dependencies")
-	for _, cmd := range commands {
-		lx.Datastore.BuildLogCreate(lx.BuildID, "milestone: "+strings.Join(cmd, " "))
-		if err := lx.runInContainer(c, cname, cmd, "", dbWC); err != nil {
-			log.Println("Command error:", cmd, err)
-			lx.Datastore.BuildLogCreate(lx.BuildID, err.Error())
-			return err
-		}
-	}
-
-	// Set up the download writer for the snap build
-	dwnWC := writecloser.NewDownloadWriteCloser(lx.BuildID, lx.Datastore)
-
-	// Run the build
-	cmd := []string{"snapcraft"}
-	lx.Datastore.BuildLogCreate(lx.BuildID, "milestone: Build snap")
-	if err := lx.runInContainer(c, cname, cmd, "/root/"+name, dwnWC); err != nil {
-		log.Println("Command error:", cmd, err)
-		lx.Datastore.BuildLogCreate(lx.BuildID, err.Error())
-		return err
-	}
-
-	// Download the file from the container
-	lx.Datastore.BuildLogCreate(lx.BuildID, fmt.Sprintf("milestone: Download file %s", dwnWC.Filename()))
-	downloadPath, err := lx.copyFile(c, cname, name, dwnWC.Filename())
-	if err != nil {
-		log.Println("Copy error:", cmd, err)
-		lx.Datastore.BuildLogCreate(lx.BuildID, err.Error())
-		return err
-	}
-	lx.Datastore.BuildUpdateDownload(lx.BuildID, downloadPath)
-
-	// Remove the container
-	lx.Datastore.BuildLogCreate(lx.BuildID, fmt.Sprintf("milestone: Removing container %s", cname))
-	if err := lx.stopAndDeleteContainer(c, cname); err != nil {
-		lx.Datastore.BuildLogCreate(lx.BuildID, err.Error())
-		return err
-	}
-
-	return err
-}
-
+// connect opens a connection to the LXD service
 func (lx *LXD) connect() (lxd.InstanceServer, error) {
 	// Get LXD socket path
 	lxdSocket, err := lxdSocketPath()
 	if err != nil {
 		log.Println("Error with lxd socket:", err)
-		if lx.BuildID != "" {
-			lx.Datastore.BuildLogCreate(lx.BuildID, err.Error())
-		}
 		return nil, err
 	}
 
@@ -143,142 +61,23 @@ func (lx *LXD) connect() (lxd.InstanceServer, error) {
 	c, err := lxd.ConnectLXDUnix(lxdSocket, nil)
 	if err != nil {
 		log.Println("Error connecting to LXD:", err)
-		if lx.BuildID != "" {
-			lx.Datastore.BuildLogCreate(lx.BuildID, err.Error())
-		}
 		return nil, err
 	}
 	return c, nil
 }
 
-func (lx *LXD) createAndStartContainer(c lxd.InstanceServer, cname, distro string) error {
-	// Container creation request
-	req := api.ContainersPost{
-		Name: cname,
-		Source: api.ContainerSource{
-			Type:  "image",
-			Alias: "fabrica-" + distro,
-		},
-	}
-
-	// Get LXD to create the container (background operation)
-	op, err := c.CreateContainer(req)
+// RunBuild runs a build by launching a container for the build request
+func (lx *LXD) RunBuild(buildID, name, repo, distro string) error {
+	// Create a new LXD connection
+	c, err := lx.connect()
 	if err != nil {
+		lx.Datastore.BuildLogCreate(buildID, err.Error())
 		return err
 	}
 
-	// Wait for the operation to complete
-	err = op.Wait()
-	if err != nil {
-		return err
-	}
-
-	// Get LXD to start the container (background operation)
-	reqState := api.ContainerStatePut{
-		Action:  "start",
-		Timeout: -1,
-	}
-
-	op, err = c.UpdateContainerState(cname, reqState, "")
-	if err != nil {
-		return err
-	}
-
-	// Wait for the operation to complete
-	return op.Wait()
-}
-
-func (lx *LXD) stopAndDeleteContainer(c lxd.InstanceServer, cname string) error {
-	// Get LXD to start the container (background operation)
-	reqState := api.ContainerStatePut{
-		Action:  "stop",
-		Timeout: -1,
-	}
-
-	op, err := c.UpdateContainerState(cname, reqState, "")
-	if err != nil {
-		return err
-	}
-
-	// Wait for the operation to complete
-	if err := op.Wait(); err != nil {
-		return err
-	}
-
-	// Delete the container, but don't wait
-	_, err = c.DeleteContainer(cname)
-	return err
-}
-
-func (lx *LXD) waitForNetwork(c lxd.InstanceServer, cname string) {
-	// Set up the writer to check for a message
-	wc := writecloser.NewFlagWriteCloser("PING")
-
-	// Run a command in the container
-	log.Println("Waiting for network...")
-	cmd := []string{"ping", "-c1", "8.8.8.8"}
-	for {
-		_ = lx.runInContainer(c, cname, cmd, "", wc)
-		if wc.Found() {
-			break
-		}
-	}
-}
-
-func (lx *LXD) runInContainer(c lxd.InstanceServer, cname string, command []string, cwd string, stdOutErr io.WriteCloser) error {
-	useDir := "/root"
-	if cwd != "" {
-		useDir = cwd
-	}
-
-	// Setup the exec request
-	req := api.ContainerExecPost{
-		Environment: containerEnv,
-		Command:     command,
-		WaitForWS:   true,
-		Cwd:         useDir,
-	}
-
-	// Setup the exec arguments (fds)
-	args := lxd.ContainerExecArgs{
-		Stdout: stdOutErr,
-		Stderr: stdOutErr,
-	}
-
-	// Get the current state
-	op, err := c.ExecContainer(cname, req, &args)
-	if err != nil {
-		return err
-	}
-
-	// Wait for it to complete
-	return op.Wait()
-}
-
-func (lx *LXD) copyFile(c lxd.InstanceServer, cname, name, filePath string) (string, error) {
-	// Generate the source path
-	inFile := path.Join("/root", name, filePath)
-
-	// Generate the destination path
-	p := service.GetPath(lx.BuildID)
-	_ = os.MkdirAll(p, os.ModePerm)
-	destFile := path.Join(p, path.Base(filePath))
-	outFile, err := os.Create(destFile)
-	if err != nil {
-		return "", fmt.Errorf("error creating snap file: %v", err)
-	}
-
-	// Get the snap file from the container
-	log.Println("Copy file from:", inFile)
-	content, _, err := c.GetContainerFile(cname, inFile)
-	if err != nil {
-		return "", fmt.Errorf("error fetching snap file: %v", err)
-	}
-	defer content.Close()
-
-	// Copy the file
-	_, err = io.Copy(outFile, content)
-	return destFile, err
+	// Run the build
+	run := newRunner(buildID, lx.Datastore, lx.SystemSrv, c)
+	return run.runBuild(name, repo, distro)
 }
 
 func containerName(name string) string {

--- a/service/lxd/lxd.go
+++ b/service/lxd/lxd.go
@@ -12,24 +12,9 @@ import (
 	"time"
 )
 
-var containerEnv = map[string]string{
-	"FLASH_KERNEL_SKIP":           "true",
-	"DEBIAN_FRONTEND":             "noninteractive",
-	"TERM":                        "xterm",
-	"SNAPCRAFT_BUILD_ENVIRONMENT": "host",
-}
-var containerCmd = [][]string{
-	{"apt", "update"},
-	{"apt", "-y", "upgrade"},
-	{"apt", "-y", "install", "build-essential"},
-	{"apt", "-y", "clean"},
-	{"snap", "install", "snapcraft", "--classic"},
-	{"snap", "list"},
-}
-
 // Service is the interface for the LXD service
 type Service interface {
-	RunBuild(buildID, name, repo, distro string) error
+	RunBuild(buildID, name, repo, branch, distro string) error
 	GetImageAlias(name string) error
 	CheckConnections() []domain.SettingAvailable
 }
@@ -67,7 +52,7 @@ func (lx *LXD) connect() (lxd.InstanceServer, error) {
 }
 
 // RunBuild runs a build by launching a container for the build request
-func (lx *LXD) RunBuild(buildID, name, repo, distro string) error {
+func (lx *LXD) RunBuild(buildID, name, repo, branch, distro string) error {
 	// Create a new LXD connection
 	c, err := lx.connect()
 	if err != nil {
@@ -77,7 +62,7 @@ func (lx *LXD) RunBuild(buildID, name, repo, distro string) error {
 
 	// Run the build
 	run := newRunner(buildID, lx.Datastore, lx.SystemSrv, c)
-	return run.runBuild(name, repo, distro)
+	return run.runBuild(name, repo, branch, distro)
 }
 
 func containerName(name string) string {

--- a/service/lxd/runner.go
+++ b/service/lxd/runner.go
@@ -1,0 +1,248 @@
+package lxd
+
+import (
+	"fmt"
+	lxd "github.com/lxc/lxd/client"
+	"github.com/lxc/lxd/shared/api"
+	"github.com/ogra1/fabrica/datastore"
+	"github.com/ogra1/fabrica/service"
+	"github.com/ogra1/fabrica/service/system"
+	"github.com/ogra1/fabrica/service/writecloser"
+	"io"
+	"log"
+	"os"
+	"path"
+	"strings"
+)
+
+// runner services to run one build in LXD
+type runner struct {
+	BuildID    string
+	Datastore  datastore.Datastore
+	SystemSrv  system.Srv
+	Connection lxd.InstanceServer
+}
+
+// newRunner creates a new LXD runner
+func newRunner(buildID string, ds datastore.Datastore, sysSrv system.Srv, c lxd.InstanceServer) *runner {
+	return &runner{
+		BuildID:    buildID,
+		Datastore:  ds,
+		SystemSrv:  sysSrv,
+		Connection: c,
+	}
+}
+
+// runBuild launches an LXD container to start the build
+func (run *runner) runBuild(name, repo, distro string) error {
+	log.Println("Run build:", name, repo, distro)
+	log.Println("Creating and starting container")
+	run.Datastore.BuildLogCreate(run.BuildID, "milestone: Creating and starting container")
+
+	// Check if we're in debug mode (retaining the container on error)
+	debug := run.SystemSrv.SnapCtlGetBool("debug")
+
+	// Generate the container name
+	cname := containerName(name)
+
+	// Create and start the LXD
+	run.Datastore.BuildLogCreate(run.BuildID, "milestone: Create container "+cname)
+	if err := run.createAndStartContainer(cname, distro); err != nil {
+		log.Println("Error creating/starting container:", err)
+		run.Datastore.BuildLogCreate(run.BuildID, err.Error())
+		return err
+	}
+
+	// Set up the database writer for the logs
+	dbWC := writecloser.NewDBWriteCloser(run.BuildID, run.Datastore)
+
+	// Wait for the network to be running
+	run.Datastore.BuildLogCreate(run.BuildID, "milestone: Waiting for the network")
+	run.waitForNetwork(cname)
+	run.Datastore.BuildLogCreate(run.BuildID, "milestone: Network is ready")
+
+	// Set up the container
+	commands := append(containerCmd, []string{"git", "clone", "--progress", repo})
+
+	run.Datastore.BuildLogCreate(run.BuildID, "milestone: Install dependencies")
+	for _, cmd := range commands {
+		run.Datastore.BuildLogCreate(run.BuildID, "milestone: "+strings.Join(cmd, " "))
+		if err := run.runInContainer(cname, cmd, "", dbWC); err != nil {
+			log.Println("Command error:", cmd, err)
+			run.Datastore.BuildLogCreate(run.BuildID, err.Error())
+			if !debug {
+				run.deleteContainer(cname)
+			}
+			return err
+		}
+	}
+
+	// Set up the download writer for the snap build
+	dwnWC := writecloser.NewDownloadWriteCloser(run.BuildID, run.Datastore)
+
+	// Run the build
+	cmd := []string{"snapcraft"}
+	run.Datastore.BuildLogCreate(run.BuildID, "milestone: Build snap")
+	if err := run.runInContainer(cname, cmd, "/root/"+name, dwnWC); err != nil {
+		log.Println("Command error:", cmd, err)
+		run.Datastore.BuildLogCreate(run.BuildID, err.Error())
+		if !debug {
+			run.deleteContainer(cname)
+		}
+		return err
+	}
+
+	// Download the file from the container
+	run.Datastore.BuildLogCreate(run.BuildID, fmt.Sprintf("milestone: Download file %s", dwnWC.Filename()))
+	downloadPath, err := run.copyFile(cname, name, dwnWC.Filename())
+	if err != nil {
+		log.Println("Copy error:", cmd, err)
+		run.Datastore.BuildLogCreate(run.BuildID, err.Error())
+		if !debug {
+			run.deleteContainer(cname)
+		}
+		return err
+	}
+	run.Datastore.BuildUpdateDownload(run.BuildID, downloadPath)
+
+	// Remove the container on successful completion
+	return run.deleteContainer(cname)
+}
+
+func (run *runner) deleteContainer(cname string) error {
+	run.Datastore.BuildLogCreate(run.BuildID, fmt.Sprintf("milestone: Removing container %s", cname))
+	if err := run.stopAndDeleteContainer(run.Connection, cname); err != nil {
+		run.Datastore.BuildLogCreate(run.BuildID, err.Error())
+		return err
+	}
+	return nil
+}
+
+func (run *runner) createAndStartContainer(cname, distro string) error {
+	// Container creation request
+	req := api.ContainersPost{
+		Name: cname,
+		Source: api.ContainerSource{
+			Type:  "image",
+			Alias: "fabrica-" + distro,
+		},
+	}
+
+	// Get LXD to create the container (background operation)
+	op, err := run.Connection.CreateContainer(req)
+	if err != nil {
+		return err
+	}
+
+	// Wait for the operation to complete
+	err = op.Wait()
+	if err != nil {
+		return err
+	}
+
+	// Get LXD to start the container (background operation)
+	reqState := api.ContainerStatePut{
+		Action:  "start",
+		Timeout: -1,
+	}
+
+	op, err = run.Connection.UpdateContainerState(cname, reqState, "")
+	if err != nil {
+		return err
+	}
+
+	// Wait for the operation to complete
+	return op.Wait()
+}
+
+func (run *runner) waitForNetwork(cname string) {
+	// Set up the writer to check for a message
+	wc := writecloser.NewFlagWriteCloser("PING")
+
+	// Run a command in the container
+	log.Println("Waiting for network...")
+	cmd := []string{"ping", "-c1", "8.8.8.8"}
+	for {
+		_ = run.runInContainer(cname, cmd, "", wc)
+		if wc.Found() {
+			break
+		}
+	}
+}
+
+func (run *runner) runInContainer(cname string, command []string, cwd string, stdOutErr io.WriteCloser) error {
+	useDir := "/root"
+	if cwd != "" {
+		useDir = cwd
+	}
+
+	// Setup the exec request
+	req := api.ContainerExecPost{
+		Environment: containerEnv,
+		Command:     command,
+		WaitForWS:   true,
+		Cwd:         useDir,
+	}
+
+	// Setup the exec arguments (fds)
+	args := lxd.ContainerExecArgs{
+		Stdout: stdOutErr,
+		Stderr: stdOutErr,
+	}
+
+	// Get the current state
+	op, err := run.Connection.ExecContainer(cname, req, &args)
+	if err != nil {
+		return err
+	}
+
+	// Wait for it to complete
+	return op.Wait()
+}
+func (run *runner) copyFile(cname, name, filePath string) (string, error) {
+	// Generate the source path
+	inFile := path.Join("/root", name, filePath)
+
+	// Generate the destination path
+	p := service.GetPath(run.BuildID)
+	_ = os.MkdirAll(p, os.ModePerm)
+	destFile := path.Join(p, path.Base(filePath))
+	outFile, err := os.Create(destFile)
+	if err != nil {
+		return "", fmt.Errorf("error creating snap file: %v", err)
+	}
+
+	// Get the snap file from the container
+	log.Println("Copy file from:", inFile)
+	content, _, err := run.Connection.GetContainerFile(cname, inFile)
+	if err != nil {
+		return "", fmt.Errorf("error fetching snap file: %v", err)
+	}
+	defer content.Close()
+
+	// Copy the file
+	_, err = io.Copy(outFile, content)
+	return destFile, err
+}
+
+func (run *runner) stopAndDeleteContainer(c lxd.InstanceServer, cname string) error {
+	// Get LXD to start the container (background operation)
+	reqState := api.ContainerStatePut{
+		Action:  "stop",
+		Timeout: -1,
+	}
+
+	op, err := c.UpdateContainerState(cname, reqState, "")
+	if err != nil {
+		return err
+	}
+
+	// Wait for the operation to complete
+	if err := op.Wait(); err != nil {
+		return err
+	}
+
+	// Delete the container, but don't wait
+	_, err = c.DeleteContainer(cname)
+	return err
+}

--- a/service/repo/build.go
+++ b/service/repo/build.go
@@ -39,12 +39,14 @@ type BuildSrv interface {
 // BuildService implements a build service
 type BuildService struct {
 	Datastore datastore.Datastore
+	LXDSrv    lxd.Service
 }
 
 // NewBuildService creates a new build service
-func NewBuildService(ds datastore.Datastore) *BuildService {
+func NewBuildService(ds datastore.Datastore, lx lxd.Service) *BuildService {
 	return &BuildService{
 		Datastore: ds,
+		LXDSrv:    lx,
 	}
 }
 
@@ -112,8 +114,7 @@ func (bld *BuildService) requestBuild(repo domain.Repo, buildID string) error {
 	_ = os.RemoveAll(repoPath)
 
 	// Run the build in an LXD container
-	lx := lxd.NewLXD(buildID, bld.Datastore)
-	if err := lx.RunBuild(repo.Name, repo.Repo, distro); err != nil {
+	if err := bld.LXDSrv.RunBuild(buildID, repo.Name, repo.Repo, distro); err != nil {
 		duration := time.Now().Sub(start).Seconds()
 		_ = bld.Datastore.BuildUpdate(buildID, statusFailed, int(duration))
 		return err

--- a/service/repo/build.go
+++ b/service/repo/build.go
@@ -114,7 +114,7 @@ func (bld *BuildService) requestBuild(repo domain.Repo, buildID string) error {
 	_ = os.RemoveAll(repoPath)
 
 	// Run the build in an LXD container
-	if err := bld.LXDSrv.RunBuild(buildID, repo.Name, repo.Repo, distro); err != nil {
+	if err := bld.LXDSrv.RunBuild(buildID, repo.Name, repo.Repo, repo.Branch, distro); err != nil {
 		duration := time.Now().Sub(start).Seconds()
 		_ = bld.Datastore.BuildUpdate(buildID, statusFailed, int(duration))
 		return err

--- a/service/system/snapctl.go
+++ b/service/system/snapctl.go
@@ -1,0 +1,26 @@
+package system
+
+import (
+	"log"
+	"os/exec"
+)
+
+// SnapCtlGet fetches a snap configuration option
+func (c *Service) SnapCtlGet(key string) (string, error) {
+	out, err := exec.Command("snapctl", "get", key).Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// SnapCtlGetBool fetches a snap configuration option that is boolean
+func (c *Service) SnapCtlGetBool(key string) bool {
+	value, err := c.SnapCtlGet(key)
+	if err != nil {
+		log.Println("Error calling snapctl:", err)
+		return false
+	}
+
+	return value == "true"
+}

--- a/service/system/system.go
+++ b/service/system/system.go
@@ -14,6 +14,9 @@ type Srv interface {
 	Memory() (float64, error)
 	Disk() (float64, error)
 	Environment() map[string]string
+
+	SnapCtlGet(key string) (string, error)
+	SnapCtlGetBool(key string) bool
 }
 
 const (

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: fabrica
 base: core18
-version: '1.0.0'
+version: '1.0.1'
 summary: your own snap build factory
 description: |
   Fabrica is a web service to be run on an lxd appliance. It spawns a


### PR DESCRIPTION
Always remove containers unless the new `debug=true` option is set.
