### PR TITLE
Interrupt build and clean up

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -8,6 +8,7 @@ type Datastore interface {
 	BuildCreate(name, repo, branch string) (string, error)
 	BuildUpdate(id, status string, duration int) error
 	BuildUpdateDownload(id, download string) error
+	BuildUpdateContainer(id, container string) error
 	BuildGet(id string) (domain.Build, error)
 	BuildDelete(id string) error
 	BuildListForRepo(name, branch string) ([]domain.Build, error)

--- a/datastore/sqlite/database.go
+++ b/datastore/sqlite/database.go
@@ -52,6 +52,7 @@ func (db *DB) CreateTables() error {
 	}
 	_, _ = db.Exec(alterRepoTableSQL)
 	_, _ = db.Exec(alterBuildTableSQL)
+	_, _ = db.Exec(alterBuildTableSQLcontainer)
 	return nil
 }
 

--- a/domain/entity.go
+++ b/domain/entity.go
@@ -15,15 +15,16 @@ type Repo struct {
 
 // Build is the requested build
 type Build struct {
-	ID       string     `json:"id"`
-	Name     string     `json:"name"`
-	Repo     string     `json:"repo"`
-	Branch   string     `json:"branch"`
-	Status   string     `json:"status"`
-	Download string     `json:"download"`
-	Duration int        `json:"duration"`
-	Created  time.Time  `json:"created"`
-	Logs     []BuildLog `json:"logs,omitempty"`
+	ID        string     `json:"id"`
+	Name      string     `json:"name"`
+	Repo      string     `json:"repo"`
+	Branch    string     `json:"branch"`
+	Status    string     `json:"status"`
+	Download  string     `json:"download"`
+	Container string     `json:"container"`
+	Duration  int        `json:"duration"`
+	Created   time.Time  `json:"created"`
+	Logs      []BuildLog `json:"logs,omitempty"`
 }
 
 // BuildLog is the log for a build

--- a/service/lxd/lxd.go
+++ b/service/lxd/lxd.go
@@ -17,6 +17,7 @@ type Service interface {
 	RunBuild(buildID, name, repo, branch, distro string) error
 	GetImageAlias(name string) error
 	CheckConnections() []domain.SettingAvailable
+	StopAndDeleteContainer(name string) error
 }
 
 // LXD services
@@ -63,6 +64,17 @@ func (lx *LXD) RunBuild(buildID, name, repo, branch, distro string) error {
 	// Run the build
 	run := newRunner(buildID, lx.Datastore, lx.SystemSrv, c)
 	return run.runBuild(name, repo, branch, distro)
+}
+
+// StopAndDeleteContainer stops and removes a container
+func (lx *LXD) StopAndDeleteContainer(name string) error {
+	c, err := lx.connect()
+	if err != nil {
+		log.Println("Error connecting to LXD:", err)
+		return err
+	}
+
+	return stopAndDeleteContainer(c, name)
 }
 
 func containerName(name string) string {

--- a/service/lxd/runner.go
+++ b/service/lxd/runner.go
@@ -128,7 +128,7 @@ func (run *runner) runBuild(name, repo, branch, distro string) error {
 
 func (run *runner) deleteContainer(cname string) error {
 	run.Datastore.BuildLogCreate(run.BuildID, fmt.Sprintf("milestone: Removing container %s", cname))
-	if err := run.stopAndDeleteContainer(run.Connection, cname); err != nil {
+	if err := stopAndDeleteContainer(run.Connection, cname); err != nil {
 		run.Datastore.BuildLogCreate(run.BuildID, err.Error())
 		return err
 	}
@@ -242,7 +242,8 @@ func (run *runner) copyFile(cname, name, filePath string) (string, error) {
 	return destFile, err
 }
 
-func (run *runner) stopAndDeleteContainer(c lxd.InstanceServer, cname string) error {
+// stopAndDeleteContainer stops and removes the container
+func stopAndDeleteContainer(c lxd.InstanceServer, cname string) error {
 	// Get LXD to start the container (background operation)
 	reqState := api.ContainerStatePut{
 		Action:  "stop",

--- a/service/lxd/runner.go
+++ b/service/lxd/runner.go
@@ -58,8 +58,9 @@ func (run *runner) runBuild(name, repo, branch, distro string) error {
 	// Check if we're in debug mode (retaining the container on error)
 	debug := run.SystemSrv.SnapCtlGetBool("debug")
 
-	// Generate the container name
+	// Generate the container name and store it in the database
 	cname := containerName(name)
+	run.Datastore.BuildUpdateContainer(run.BuildID, cname)
 
 	// Create and start the LXD
 	run.Datastore.BuildLogCreate(run.BuildID, "milestone: Create container "+cname)

--- a/service/repo/build_actions.go
+++ b/service/repo/build_actions.go
@@ -24,9 +24,15 @@ func (bld *BuildService) BuildDelete(id string) error {
 		return err
 	}
 
+	// Remove the stored files
 	if build.Download != "" {
 		dir := path.Dir(build.Download)
 		os.RemoveAll(dir)
+	}
+
+	// Stop and delete the running container
+	if build.Container != "" {
+		bld.LXDSrv.StopAndDeleteContainer(build.Container)
 	}
 
 	// Remove the database records for the build and logs

--- a/service/system/snapctl.go
+++ b/service/system/snapctl.go
@@ -11,6 +11,7 @@ func (c *Service) SnapCtlGet(key string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	log.Println("---snapctl:", key, string(out))
 	return string(out), nil
 }
 

--- a/service/system/snapctl.go
+++ b/service/system/snapctl.go
@@ -3,6 +3,7 @@ package system
 import (
 	"log"
 	"os/exec"
+	"strings"
 )
 
 // SnapCtlGet fetches a snap configuration option
@@ -11,7 +12,6 @@ func (c *Service) SnapCtlGet(key string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	log.Println("---snapctl:", key, string(out))
 	return string(out), nil
 }
 
@@ -23,5 +23,5 @@ func (c *Service) SnapCtlGetBool(key string) bool {
 		return false
 	}
 
-	return value == "true"
+	return strings.Contains(value, "true")
 }

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: fabrica
 base: core18
-version: '1.0.1'
+version: '1.0.2'
 summary: your own snap build factory
 description: |
   Fabrica is a web service to be run on an lxd appliance. It spawns a


### PR DESCRIPTION
- Store the name of the container for each build.
- Remove a build container when it is deleted.

Fix detection for checking the debug option.